### PR TITLE
Commander module as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "licenses": [{
         "type":       "MIT",
         "url":        "http://opensource.org/licenses/mit-license.php"
+    "dependencies": {
+        "commander": "0.6.0"
+     }
     }],
 
     "engines": {


### PR DESCRIPTION
Commander module needs to be listed as dependency, as referenced in line 4 of coffee-watcher/lib/coffee-watcher.js
